### PR TITLE
fix: properly register CanvasSpriteRenderer

### DIFF
--- a/src/packages.json
+++ b/src/packages.json
@@ -220,7 +220,7 @@
         },
         {
             "name": "@pixi/canvas-sprite",
-            "canvasPlugin": ["prepare", "CanvasSpriteRenderer"],
+            "canvasPlugin": ["sprite", "CanvasSpriteRenderer"],
             "dependencies": [
                 "@pixi/canvas-renderer",
                 "@pixi/sprite"


### PR DESCRIPTION
fixed a typo that results in the sprite renderer not being properly registered