### PR TITLE
Improve CanvasRenderer support and fix filter imports

### DIFF
--- a/src/CodeUtils.ts
+++ b/src/CodeUtils.ts
@@ -38,6 +38,12 @@ function rendererPlugin(rendererName:string, {name, rendererPlugin, canvasPlugin
             `${rendererName}.registerPlugin('${apiName}', ${namespace}.${className})`
         ];
     }
+    // avoid duplicate class imports for CanvasRenderer plugins
+    else if (rendererName === 'CanvasRenderer' && rendererPlugin && rendererPlugin[1] === className) {
+        return [
+            `${rendererName}.registerPlugin('${apiName}', ${className})`
+        ];
+    }
     else {
         return [
             `import { ${className} } from '${name}'`,

--- a/src/CodeUtils.ts
+++ b/src/CodeUtils.ts
@@ -113,7 +113,7 @@ export function createBundleCode(packages:string[]) {
         filters.forEach(pkg => {
             const imports = pkg.filter.join(', ');
             filterNames.push(imports);
-            lines.push(`import { ${imports} } from '${pkg.name}' }`);
+            lines.push(`import { ${imports} } from '${pkg.name}'`);
         });
         lines.push(`export const filters = {\n  ${filterNames.join(',\n  ')}\n}`);
     }

--- a/src/packages.json
+++ b/src/packages.json
@@ -40,6 +40,7 @@
         {
             "name": "@pixi/interaction",
             "rendererPlugin": ["interaction", "InteractionManager"],
+            "canvasPlugin": ["interaction", "InteractionManager"],
             "dependencies": ["@pixi/display"]
         },
         {


### PR DESCRIPTION
InteractionManager was not registered for CanvasRenderer
Enabling this requires some extra logic to prevent two InteractionManager class imports
Filter imports had a syntax typo